### PR TITLE
feat: standardized auth request

### DIFF
--- a/neps/nep-0413.md
+++ b/neps/nep-0413.md
@@ -100,7 +100,7 @@ In order to create a signature, `signMessage` must:
 > If the wallet does not hold any `full-access` keys, then it must return an error.
 
 ### Standardized Authentication Request
-In order to prevent Dapps from using random strings to prove ownership of an account and to reduce user alertness when asked to sign such messages, this NEP includes a standardized `message` value that will be used for these use cases. When wallets detect this as the message value they will display a UI to the user that they are being asked to prove ownership and the actual signed message could be hidden or displayed to the user with less visibility. The value of `message` in these cases will be exactly `"NEP-413-PROVE-ACCOUNT-OWNERSHIP"`.
+In order to prevent Dapps from using random strings to prove ownership of an account and to reduce user alertness when asked to sign such messages, this NEP includes a standardized `message` value that will be used for these use cases. When wallets detect this as the message value they will display a UI to the user that they are being asked to prove ownership for authentication purposes and the actual signed message could be displayed to the user with less visibility. The value of `message` in these cases will be exactly `"NEP-413-PROVE-ACCOUNT-OWNERSHIP"`.
 
 ### Example
 Assuming that the `signMessage` method was invoked, and that:

--- a/neps/nep-0413.md
+++ b/neps/nep-0413.md
@@ -99,6 +99,9 @@ In order to create a signature, `signMessage` must:
 
 > If the wallet does not hold any `full-access` keys, then it must return an error.
 
+### Standardized Authentication Request
+In order to prevent Dapps from using random strings to prove ownership of an account and to reduce user alertness when asked to sign such messages, this NEP includes a standardized `message` value that will be used for these use cases. When wallets detect this as the message value they will display a UI to the user that they are being asked to prove ownership and the actual signed message could be hidden or displayed to the user with less visibility. The value of `message` in these cases will be exactly `"NEP-413-PROVE-ACCOUNT-OWNERSHIP"`.
+
 ### Example
 Assuming that the `signMessage` method was invoked, and that:
 - The input `message` is `"hi"`


### PR DESCRIPTION
This PR adds a suggested standardized `message` value specifically for the ownership proofs for authentication purposes to prevent Dapps from using random strings and to reduce user alertness when asked to sign random messages